### PR TITLE
gulp compile return undefined

### DIFF
--- a/app/templates/gulpfile.coffee
+++ b/app/templates/gulpfile.coffee
@@ -48,6 +48,7 @@ gulp.task 'compile', ['lint'], ->
       .pipe $.espower()
       .pipe gulp.dest('./compile/test')
   )
+  undefined
 
 gulp.task 'istanbul', ['clean:coverage', 'compile'], (cb) ->
   gulp.src ['./compile/src/**/*.js']


### PR DESCRIPTION
coffee's automatically return value does not work well
