### PR TITLE
Set current year as default in LICENSE

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -74,6 +74,7 @@ HubotScriptGenerator.prototype.app = function app() {
 
   this.userName = this.user.git.name();
   this.userEmail = this.user.git.email();
+  this.currentYear = new Date().getFullYear();
 
   this.mkdir('src');
   this.copy('src/template.coffee', 'src/' + this.scriptName + '.coffee');

--- a/app/templates/LICENSE
+++ b/app/templates/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014 <%= userName %>
+Copyright <%= currentYear %> <%= userName %>
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
This generator is so nice.
However, the year specified in generated LICENSE file is always 2014.
This commit enable us to set current year as default in LICENSE file.
Thanks.